### PR TITLE
chore: change library to seyfert in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## 📦 Packages:
 
 - ⚡️ [Nodejs](https://nodejs.org/en/) - JavaScript runtime.
-- 🤖 [Discord.js](https://discord.js.org/) - Discord API.
+- 🤖 [Seyfert](https://www.seyfert.dev/) - Discord API.
 - 📘 [Typescript](https://www.typescriptlang.org/) - TypeScript language.
 
 ## 🚀 Getting Started:


### PR DESCRIPTION
This PR updates the README file to show the new library in the project which is [Seyfert](https://www.seyfert.dev/).